### PR TITLE
Prevent fatal errror

### DIFF
--- a/src/Segment.php
+++ b/src/Segment.php
@@ -84,7 +84,7 @@ class Segment implements \IteratorAggregate, \Countable
      */
     public function getIterator()
     {
-        return new RecursiveIteratorIterator(new SegmentIterator($this->children), 1);
+        return new \RecursiveIteratorIterator(new SegmentIterator($this->children), 1);
     }
 
     /**


### PR DESCRIPTION
This change causes that `RecursiveIteratorIterator` is not searched for in the `Odtphp` namespace.