### PR TITLE
Fix PclZip error with PHP 7

### DIFF
--- a/lib/pclzip.lib.php
+++ b/lib/pclzip.lib.php
@@ -187,7 +187,7 @@
   //   extract() : Extract the content of the archive
   //   properties() : List the properties of the archive
   // --------------------------------------------------------------------------------
-  class PclZip
+  class __construct()
   {
     // ----- Filename of the zip file
     var $zipname = '';

--- a/lib/pclzip.lib.php
+++ b/lib/pclzip.lib.php
@@ -187,7 +187,7 @@
   //   extract() : Extract the content of the archive
   //   properties() : List the properties of the archive
   // --------------------------------------------------------------------------------
-  class __construct()
+  class PclZip()
   {
     // ----- Filename of the zip file
     var $zipname = '';
@@ -212,7 +212,7 @@
   //   Note that no real action is taken, if the archive does not exist it is not
   //   created. Use create() for that.
   // --------------------------------------------------------------------------------
-  function PclZip($p_zipname)
+  function __construct($p_zipname)
   {
 
     // ----- Tests the zlib


### PR DESCRIPTION
An error occured with PHP 7 :

Methods with the same name as their class will not be constructors in a future version of PHP; PclZip has a deprecated constructor